### PR TITLE
Update image to RHEL 10.2 (rhel-10-2-eus-06-08-26)

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -1,7 +1,7 @@
 ---
 virtualmachines:
   - name: "rhel"
-    image: "rhel-10-0-07-09-25-3"
+    image: rhel-10-2-eus-06-08-26
     bootloader: efi
     memory: "4G"
     cores: 1


### PR DESCRIPTION
## Summary
- Updated `instances.yaml` image to `rhel-10-2-eus-06-08-26`
- Part of RHEL 10.2 lab migration

## Lab
Configure terminal session recording