### PR TITLE
Update image to RHEL 10.2 (rhel-10-2-eus-06-08-26)

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -6,6 +6,7 @@ virtualmachines:
     memory: "4G"
     cores: 1
     image_size: "40G"
+    register_satellite: false
     tags:
       - key: "AnsibleGroup"
         value: "bastions"

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -12,10 +12,10 @@ virtualmachines:
         value: "bastions"
     networks:
       - default
-    packages:
-      - cockpit
-      - sssd-proxy
-      - pcp
+    # packages:
+    # - cockpit
+    # - sssd-proxy
+    # - pcp
     services:
       - name: cockpit
         ports:

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -13,11 +13,11 @@
 # Create a done file to signal we have finished
 #touch /root/post-run.log.done
 
-# Enable cockpit functionality in showroom.
 # Unregister and register the VM
 subscription-manager clean
 subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
 
+# Enable cockpit functionality in showroom.
 dnf -y remove tlog cockpit-session-recording
 echo "[WebService]" > /etc/cockpit/cockpit.conf
 echo "Origins = https://cockpit-${GUID}.${DOMAIN}" >> /etc/cockpit/cockpit.conf

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -14,6 +14,10 @@
 #touch /root/post-run.log.done
 
 # Enable cockpit functionality in showroom.
+# Unregister and register the VM
+subscription-manager clean
+subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
+
 dnf -y remove tlog cockpit-session-recording
 echo "[WebService]" > /etc/cockpit/cockpit.conf
 echo "Origins = https://cockpit-${GUID}.${DOMAIN}" >> /etc/cockpit/cockpit.conf


### PR DESCRIPTION
## Summary
- Updated `instances.yaml` image to `rhel-10-2-eus-06-08-26`
- Disabled satellite registration (`register_satellite: false`)
- Commented out packages block
- Added subscription-manager clean & re-register to `setup-rhel.sh`
- Part of RHEL 10.2 lab migration

## Lab
Configure terminal session recording